### PR TITLE
Removed hard coded git ssh key path

### DIFF
--- a/cmd/microservice/root.go
+++ b/cmd/microservice/root.go
@@ -17,5 +17,8 @@ func init() {
 	RootCmd.AddCommand(updateRepoCMD)
 	RootCmd.AddCommand(gitTestCMD)
 
+	viper.BindEnv("tools.server.gitRepo.git-key", "GIT_KEY")
 	viper.BindEnv("tools.server.gitRepo.branch", "GIT_BRANCH")
+
+	viper.SetDefault("tools.server.gitRepo.git-key", "/Users/freshteapot/dolittle/.ssh/test-deploy")
 }

--- a/cmd/microservice/server.go
+++ b/cmd/microservice/server.go
@@ -37,6 +37,11 @@ var serverCMD = &cobra.Command{
 			panic("GIT_BRANCH required")
 		}
 
+		gitSshKeysFolder := viper.GetString("tools.server.gitRepo.git-key")
+		if gitSshKeysFolder == "" {
+			panic("GIT_KEY required")
+		}
+
 		kubeconfig := viper.GetString("tools.server.kubeConfig")
 		// TODO hoist localhost into viper
 		config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
@@ -64,7 +69,7 @@ var serverCMD = &cobra.Command{
 			"/tmp/dolittle-k8s",
 			gitRepoBranch,
 			// TODO fix this, then update deployment
-			"/Users/freshteapot/dolittle/.ssh/test-deploy",
+			gitSshKeysFolder,
 		)
 
 		microserviceService := microservice.NewService(gitRepo, k8sRepo, clientset)


### PR DESCRIPTION
ssh key path was hard coded to one specific dev's machine. I made it configurable so that it's easier for others to run platform  api local.